### PR TITLE
Fix pair plot download button and add regression test

### DIFF
--- a/pages/data_explorer.py
+++ b/pages/data_explorer.py
@@ -139,7 +139,7 @@ def main() -> None:
                 with tempfile.NamedTemporaryFile(suffix=f".{export_fmt}") as tmp:
                     viz.export_figure(fig_pair, Path(tmp.name))
                     tmp.seek(0)
-                st.download_button(
+                    st.download_button(
                         "Download Plot",
                         data=tmp.read(),
                         file_name=f"pair_plot.{export_fmt}",

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -76,6 +76,18 @@ def test_data_explorer_visualization_widgets_exist():
     assert "Generate Heatmap" in content
 
 
+def test_pair_plot_export(tmp_path):
+    df = pd.DataFrame({
+        "a": [1, 2, 3, 4],
+        "b": [4, 3, 2, 1],
+        "cat": ["x", "y", "x", "y"],
+    })
+    fig = viz.pair_plot(df, columns=["a", "b"], hue="cat")
+    out_file = tmp_path / "pair.png"
+    viz.export_figure(fig, out_file)
+    assert out_file.exists() and out_file.stat().st_size > 0
+
+
 def test_time_series_page_runs(monkeypatch):
     import streamlit as st
     from pages import time_series


### PR DESCRIPTION
## Summary
- ensure the temporary file remains open when reading in data explorer
- add regression test for pair plot export

## Testing
- `pytest -q`