### PR TITLE
Add caching for models and transforms

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -66,6 +66,15 @@ def test_model_caching():
     assert first is second
 
 
+def test_training_function_caching():
+    df = sample_reg_df()
+    X = df.drop(columns=["target"])
+    y = df["target"]
+    first = model.train_linear_regression(X, y)
+    second = model.train_linear_regression(X, y)
+    assert first is second
+
+
 def test_regression_training_functions():
     df = sample_reg_df()
     X_train, X_test, y_train, y_test = model.train_test_split_data(df, "target")

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -67,3 +67,28 @@ def test_scale_features_non_numeric():
     df = sample_df().fillna({"cat": "b"})
     with pytest.raises(TypeError):
         transform.scale_features(df, ["cat"], method="standard")
+
+
+def test_cached_transformations_identical():
+    import streamlit as st
+    from utils import components
+
+    df = sample_df()
+    st.session_state.clear()
+    first = components._cached_transformations(
+        df,
+        "Fill Mean",
+        tuple(),
+        "One-Hot",
+        tuple(),
+        "Standard",
+    )
+    second = components._cached_transformations(
+        df,
+        "Fill Mean",
+        tuple(),
+        "One-Hot",
+        tuple(),
+        "Standard",
+    )
+    assert first is second

--- a/utils/model.py
+++ b/utils/model.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, Tuple
 
 import pandas as pd
 import numpy as np
+import streamlit as st
 from joblib import dump
 from sklearn.model_selection import train_test_split, cross_val_score
 from sklearn.linear_model import LogisticRegression, LinearRegression
@@ -66,6 +67,7 @@ def train_test_split_data(
     )
 
 
+@st.cache_resource
 @cache_model
 def train_logistic_regression(
     X: pd.DataFrame,
@@ -80,6 +82,7 @@ def train_logistic_regression(
     return model
 
 
+@st.cache_resource
 @cache_model
 def train_random_forest_classifier(
     X: pd.DataFrame,
@@ -99,6 +102,7 @@ def train_random_forest_classifier(
     return model
 
 
+@st.cache_resource
 @cache_model
 def train_xgboost_classifier(
     X: pd.DataFrame,
@@ -143,6 +147,7 @@ def detect_problem_type(y: pd.Series) -> str:
     return "classification"
 
 
+@st.cache_resource
 @cache_model
 def train_linear_regression(
     X: pd.DataFrame,
@@ -154,6 +159,7 @@ def train_linear_regression(
     return model
 
 
+@st.cache_resource
 @cache_model
 def train_decision_tree_regressor(
     X: pd.DataFrame,
@@ -168,6 +174,7 @@ def train_decision_tree_regressor(
     return model
 
 
+@st.cache_resource
 @cache_model
 def train_random_forest_regressor(
     X: pd.DataFrame,
@@ -187,6 +194,7 @@ def train_random_forest_regressor(
     return model
 
 
+@st.cache_resource
 @cache_model
 def train_xgboost_regressor(
     X: pd.DataFrame,


### PR DESCRIPTION
## Summary
- cache model training functions using `st.cache_resource`
- cache transformation results with a helper in `components`
- test caching for transformations and training functions

## Testing
- `pytest -q`