### PR TITLE
Add logging configuration utilities

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -181,6 +181,7 @@ After completing a milestone, create a pull request with your changes for review
 - [x] Integrated evaluation metrics and plots into the Data Explorer page
 - [x] Implemented modeling page with model selection, training, cross-validation, and export functionality
 - [x] Added histogram, box plot, violin plot, and heatmap UI with export options
+- [x] Added logging utilities and integrated logging across the app
 
 ## PR17: Robust Error Handling
 

--- a/app.py
+++ b/app.py
@@ -2,6 +2,9 @@
 
 import streamlit as st
 from utils import ui
+from utils.logging import configure_logging
+
+configure_logging()
 
 st.set_page_config(page_title="PredictStream", layout="wide")
 

--- a/pages/data_explorer.py
+++ b/pages/data_explorer.py
@@ -6,6 +6,10 @@ from utils import data as data_utils
 from utils import eda
 from utils import ui
 from utils import components
+import logging
+from utils.logging import configure_logging
+
+configure_logging()
 
 
 
@@ -47,6 +51,9 @@ def main() -> None:
                     )
                     st.success(f"{name} loaded!")
                 except (ValueError, TypeError) as exc:
+                    logging.getLogger(__name__).error(
+                        "Failed to load sample data %s: %s", name, exc
+                    )
                     st.error(f"Failed to load sample data: {exc}")
 
         with st.expander("Help"):

--- a/pages/modeling.py
+++ b/pages/modeling.py
@@ -10,6 +10,9 @@ import pandas as pd
 import streamlit as st
 
 from utils import model, predict, ui
+from utils.logging import configure_logging
+
+configure_logging()
 
 st.set_page_config(page_title="Modeling", layout="wide")
 

--- a/pages/prediction.py
+++ b/pages/prediction.py
@@ -11,6 +11,9 @@ import streamlit as st
 from utils import data as data_utils
 from utils import predict
 from utils import ui
+from utils.logging import configure_logging
+
+configure_logging()
 
 st.set_page_config(page_title="Prediction", layout="wide")
 

--- a/pages/report.py
+++ b/pages/report.py
@@ -11,6 +11,9 @@ import streamlit as st
 from utils import data as data_utils
 from utils import eda
 from utils import ui
+from utils.logging import configure_logging
+
+configure_logging()
 
 st.set_page_config(page_title="Report", layout="wide")
 

--- a/pages/time_series.py
+++ b/pages/time_series.py
@@ -7,6 +7,9 @@ import pandas as pd
 import streamlit as st
 
 from utils import ui, viz
+from utils.logging import configure_logging
+
+configure_logging()
 
 st.set_page_config(page_title="Time Series", layout="wide")
 

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,10 @@
+import logging
+from importlib import reload
+from utils import logging as log_utils
+
+
+def test_configure_logging_sets_level():
+    reload(log_utils)
+    log_utils.configure_logging(level=logging.INFO)
+    assert logging.getLogger().level == logging.INFO
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -10,6 +10,7 @@ from . import eval
 from . import predict
 from . import ui
 from . import transform
+from . import logging
 
 __all__ = [
     "config",
@@ -22,4 +23,5 @@ __all__ = [
     "predict",
     "ui",
     "transform",
+    "logging",
 ]

--- a/utils/components.py
+++ b/utils/components.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import tempfile
+import logging
 
 import pandas as pd
 import streamlit as st
@@ -441,6 +442,9 @@ def classification_training_section(data: pd.DataFrame) -> None:
                     )
         except Exception as exc:  # pragma: no cover - training can fail for many reasons
             progress.progress(0)
+            logging.getLogger(__name__).exception(
+                "Classification training failed: %s", exc
+            )
             st.error(f"Classification training failed: {exc}")
 
     st.subheader("Detected Problem Type")
@@ -637,6 +641,9 @@ def regression_training_section(data: pd.DataFrame) -> None:
                     )
         except Exception as exc:  # pragma: no cover - training can fail for many reasons
             progress_r.progress(0)
+            logging.getLogger(__name__).exception(
+                "Regression training failed: %s", exc
+            )
             st.error(f"Regression training failed: {exc}")
 
     if st.button("Compare Regression Models") and feature_cols_r:

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,0 +1,14 @@
+import logging
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure root logger if not already configured."""
+    root = logging.getLogger()
+    if not root.handlers:
+        logging.basicConfig(
+            level=level,
+            format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        )
+    else:
+        root.setLevel(level)
+

--- a/utils/viz.py
+++ b/utils/viz.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional
+import logging
 
 import pandas as pd
 import plotly.express as px
@@ -135,20 +136,26 @@ def export_figure(fig: object, path: Path) -> None:
         if isinstance(fig, go.Figure):
             fig.write_html(str(path))
         else:
+            logging.getLogger(__name__).error("HTML export requires a Plotly figure")
             raise ValueError("HTML export requires a Plotly figure")
     elif ext in {".png", ".jpg", ".jpeg"}:
         if isinstance(fig, go.Figure):
             try:
                 fig.write_image(str(path))
             except ValueError as exc:
+                logging.getLogger(__name__).exception(
+                    "Static image export failed: %s", exc
+                )
                 raise RuntimeError(
                     "Static image export requires the kaleido package"
                 ) from exc
         elif isinstance(fig, plt.Figure):
             fig.savefig(path)
         else:
+            logging.getLogger(__name__).error("Unsupported figure type for image export")
             raise ValueError("Unsupported figure type for image export")
     else:
+        logging.getLogger(__name__).error("Unsupported export format: %s", ext)
         raise ValueError(f"Unsupported export format: {ext}")
 
 


### PR DESCRIPTION
## Summary
- add utils.logging with `configure_logging`
- initialize logging in app and all pages
- log errors when sample data fails to load
- log training errors in component helpers
- log file validation and export errors
- update TODO
- test logging configuration

## Testing
- `pytest -q`